### PR TITLE
Use make-temp-file to create temporary file for screenshot

### DIFF
--- a/password-store-otp.el
+++ b/password-store-otp.el
@@ -78,7 +78,7 @@ after `password-store-timeout' seconds."
                              (format-time-string "%Y-%m-%dT%T"))))
           (expand-file-name fname
                             password-store-otp-screenshots-path))
-      (format "/tmp/%s.png" (make-temp-name entry-base)))))
+      (make-temp-file entry-base nil ".png"))))
 
 (defmacro password-store-otp--related-error (&rest body)
   "Catch otp related errors in BODY and displays a better error message."


### PR DESCRIPTION
Instead of hard-coding `/tmp`, use `make-temp-file`. This function exists since Emacs 21 and enables a user to define where temporary files are stored.